### PR TITLE
Adding env files for different OS's

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,0 +1,28 @@
+name: swd6_hpp
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - dask-jobqueue
+  - numpy
+  - xarray
+  - jupyterlab
+  - numba
+  - matplotlib
+  - dask-mpi
+  - python=3.9
+  - dask
+  - jupyter-book
+  - python-graphviz
+  - cudatoolkit
+  - pip
+  - pip:
+    - algorithms
+    - eliot
+    - eliot-tree
+    - jax
+    - jaxlib
+    - line-profiler
+    - pyinstrument
+    - ray
+    - snakeviz

--- a/environment_win_native.yml
+++ b/environment_win_native.yml
@@ -1,0 +1,27 @@
+name: swd6_hpp
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - dask-jobqueue
+  - numpy
+  - xarray
+  - jupyterlab
+  - numba
+  - matplotlib
+  - dask-mpi
+  - python=3.9
+  - cupy
+  - dask
+  - jupyter-book
+  - python-graphviz
+  - cudatoolkit
+  - pip
+  - pip:
+    - algorithms
+    - eliot
+    - eliot-tree
+    - line-profiler
+    - pyinstrument
+    - ray
+    - snakeviz


### PR DESCRIPTION
Due to some dependencies not being shared across operating systems i've created 2 additional environment files with adjustments for MacOS and Windows native.

This is probably not the ideal solution but for now will do.

@patricia-ternes let me know how you get on with your linux box before merging this!